### PR TITLE
Update Plugin.php

### DIFF
--- a/class/Plugin.php
+++ b/class/Plugin.php
@@ -66,7 +66,7 @@ class Plugin
             foreach ($pluginsList as $plugin) {
                 //                if (file_exists($GLOBALS['xoops']->path("modules/{$this->helper->getDirname()}/plugins/{$plugin}/{$plugin}.php"))) {
                 $dirname   = $this->helper->getDirname();
-                $className = "\XoopsModules\{$dirname}\Plugins\{$plugin}\PluginItem";
+                $className = "\XoopsModules\\" . ucfirst($dirname) . "\Plugins\\{$plugin}\PluginItem";
                 if (\class_exists($className)) {
                     $this->plugins[] = $plugin;
                 }
@@ -79,7 +79,7 @@ class Plugin
         foreach ($this->plugins as $plugin) {
             //            require $GLOBALS['xoops']->path("modules/{$this->helper->getDirname()}/plugins/{$plugin}/{$plugin}.php");
             $dirname   = $this->helper->getDirname();
-            $className = "\XoopsModules\{$dirname}\Plugins\{$plugin}\PluginItem";
+            $className = "\XoopsModules\\" . ucfirst($dirname) . "\Plugins\\{$plugin}\PluginItem";
             if (!\class_exists($className)) {
                 continue;
             }


### PR DESCRIPTION
Plugin class names are incorrect resulting in these classes failing to preload and set up events.
It might also be good to rename class/registry.php to class/Registry.php for consistency with its contained class name.